### PR TITLE
File tree brakes after filename interference FIXED

### DIFF
--- a/src/project/ProjectModel.js
+++ b/src/project/ProjectModel.js
@@ -189,6 +189,7 @@ define(function (require, exports, module) {
      */
     function doCreate(path, isFolder) {
         var d = new $.Deferred();
+        var fs = _getFSObject(path);
 
         var name = FileUtils.getBaseName(path);
         if (!isValidFilename(name, _invalidChars)) {


### PR DESCRIPTION
# Issue fixed.
Line added in doCreate() method;
**" var fs = _getFSObject(path); "**
This line refreshes the cache by updating the path.